### PR TITLE
Display User Info Instead of PlaceHolder in Settings

### DIFF
--- a/client/app/account/Settings.js
+++ b/client/app/account/Settings.js
@@ -1,13 +1,40 @@
 'use client';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import styles from './Settings.module.css';
 import EditableField from './EditableField';
 
 const Settings = () => {
     const [activeTab, setActiveTab] = useState('Account Info');
-    const [email, setEmail] = useState('user@example.com');
-    const [password, setPassword] = useState('********');
-    const [phoneNumber, setPhoneNumber] = useState('123-456-7890');
+    const [email, setEmail] = useState('');
+    const [password, setPassword] = useState('********'); // This can remain a placeholder
+    const [phoneNumber, setPhoneNumber] = useState('');
+
+    useEffect(() => {
+        // Fetch user profile information on component load
+        const fetchUserData = async () => {
+            try {
+                const token = localStorage.getItem('token');
+                const response = await fetch(`${process.env.NEXT_PUBLIC_SERVER_URL}/api/user/profile`, {
+                    method: 'GET',
+                    headers: {
+                        'Authorization': `Bearer ${token}`,
+                    }
+                });
+
+                if (response.ok) {
+                    const data = await response.json();
+                    setEmail(data.email); // Set the actual email from the backend
+                    setPhoneNumber(data.phone); // Set the actual phone number from the backend
+                } else {
+                    console.error('Failed to fetch user data');
+                }
+            } catch (error) {
+                console.error('Error fetching user data:', error);
+            }
+        };
+
+        fetchUserData();
+    }, []);
 
     const renderTabContent = () => {
         switch (activeTab) {

--- a/server/server.js
+++ b/server/server.js
@@ -18,7 +18,7 @@ const nutritionGetRoute = require('./nutrition/nutritionGet');
 const nutritionUpdateRoute = require('./nutrition/nutritionUpdate');
 const { body, validationResult } = require('express-validator');
 const { initializeCronJobs } = require('./email_noti/cronJobs');
-const userUpdateRoutes = require('./user/userUpdate'); // Import the user routes
+const userRoutes = require('./user/user'); 
 
 const app = express();
 const registerRoute = require('./register');
@@ -72,7 +72,7 @@ app.use('/api/plan/remove-recipe', planRemoveRoute);
 app.use('/api/nutrition-get', nutritionGetRoute);
 app.use('/api/nutrition-update', nutritionUpdateRoute);
 app.use('/api/favorites', favoriteRoutes);
-app.use('/api/user', userUpdateRoutes); // Register the route for user-related actions
+app.use('/api/user', userRoutes);
 
 
 

--- a/server/user/user.js
+++ b/server/user/user.js
@@ -6,27 +6,44 @@ const router = express.Router();
 // Middleware to authenticate token
 const authenticateToken = (req, res, next) => {
     const authHeader = req.headers['authorization'];
-    const token = authHeader && authHeader.split(' ')[1]; // Extract token from Bearer scheme
+    const token = authHeader && authHeader.split(' ')[1];
 
     if (!token) {
         return res.status(401).json({ message: 'Token not found' });
     }
 
-    // Verify the token
     jwt.verify(token, process.env.JWT_SECRET, (err, decoded) => {
         if (err) {
             return res.status(403).json({ message: 'Invalid token' });
         }
 
-        // Ensure the user_id is available in the decoded token
-        if (!decoded || !decoded.id) {
-            return res.status(403).json({ message: 'Invalid token payload' });
-        }
-
-        req.user = decoded; // Assign decoded token to req.user
+        req.user = decoded;
         next();
     });
 };
+
+// Endpoint to get user profile data
+router.get('/profile', authenticateToken, async (req, res) => {
+    const userId = req.user.id;
+
+    try {
+        const result = await pool.query(`
+            SELECT u.email, up.first_name, up.last_name, up.phone
+            FROM users u
+            JOIN user_profiles up ON u.user_id = up.user_id
+            WHERE u.user_id = $1
+        `, [userId]);
+
+        if (result.rows.length === 0) {
+            return res.status(404).json({ message: 'User not found' });
+        }
+
+        res.status(200).json(result.rows[0]);
+    } catch (error) {
+        console.error('Error fetching profile:', error);
+        res.status(500).json({ message: 'Internal server error' });
+    }
+});
 
 // Endpoint to update user email
 router.put('/update-email', authenticateToken, async (req, res) => {


### PR DESCRIPTION

<img width="960" alt="settings2" src="https://github.com/user-attachments/assets/ad935315-0071-4038-9bca-38227a6af091">
<img width="822" alt="update1" src="https://github.com/user-attachments/assets/6888f221-50f2-42cf-a4c7-f83aec81a76e">

**Issue / Feature:**  
Add `/profile` endpoint and display real user data on settings page.

**Description:**  
This update introduces a new `/profile` endpoint for retrieving user profile data. The settings page now fetches and displays the user’s actual email and phone number instead of placeholders on page load. Before, users could only see their current email address displayed after they edit their previous one. However, upon logging in and navigating to the settings window, users could only see placeholders for their email address and phone number. 

**What's in this change?:**  
- Added a `GET /profile` endpoint to `user.js` for fetching user details.
- Updated `Settings.js` to call this endpoint and set the initial state with real user data.
- Adjusted `server.js` to ensure all user routes are accessible under `/api/user`.

**What's left to do?:**  
No further steps required for this feature.

**Testing changes:**  
Verified that the settings page loads the actual email and phone number immediately, with successful fetching from `/profile` endpoint.

**Supplemental material (optional, screenshots of frontend changes, api testing, notifications):**  
Images show before and after for comparison.
