### PR TITLE
Updated email/phone number cannot already be associated with an account

### DIFF
--- a/client/app/account/EditableField.js
+++ b/client/app/account/EditableField.js
@@ -14,6 +14,12 @@ const EditableField = ({ label, value, onSave, isPassword = false, separator = f
     const [successMessage, setSuccessMessage] = useState('');
     const [errorMessage, setErrorMessage] = useState('');
 
+    const handleCancel = () => {
+        setNewValue(value); 
+        setIsEditing(false);
+        setErrorMessage(''); 
+    };
+
     const validatePassword = (password) => {
         const specialCharPattern = /[!@#$%^&*(),.?":{}|<>]/;
         const numberPattern = /[0-9]/;
@@ -183,7 +189,10 @@ const EditableField = ({ label, value, onSave, isPassword = false, separator = f
                                 </ul>
                             </>
                         )}
-                        <button onClick={handleSave} className={styles.bubbleButton}>Save</button>
+                        <div className={styles.buttonContainer}>
+                            <button onClick={handleSave} className={styles.bubbleButton}>Save</button>
+                            <button onClick={handleCancel} className={styles.cancelButton}>Cancel</button>
+                        </div>
                     </div>
                 ) : (
                     <div className={styles.displayContainer}>

--- a/client/app/account/Settings.module.css
+++ b/client/app/account/Settings.module.css
@@ -180,3 +180,20 @@
     font-size: 1rem; /* Icon size */
 }
 
+.cancelButton {
+    background-color: #ccc;
+    color: #333;
+    border: none;
+    padding: 0.3rem 0.8rem;
+    border-radius: 15px;
+    font-size: 0.8rem;
+    cursor: pointer;
+    margin-left: 0.5rem;
+}
+
+.buttonContainer {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+}
+

--- a/server/user/user.js
+++ b/server/user/user.js
@@ -55,6 +55,23 @@ router.put('/update-email', authenticateToken, async (req, res) => {
         return res.status(400).json({ message: 'Email is required' });
     }
 
+    //Must follow email format
+    const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailPattern.test(email)) {
+        return res.status(400).json({ message: 'Invalid email format' });
+    }
+
+    //Adding check for existing account with email
+    try {
+        const emailExists = await pool.query('SELECT user_id FROM users WHERE email = $1', [email]);
+        if (emailExists.rows.length > 0 && emailExists.rows[0].user_id !== userId) {
+            return res.status(409).json({ message: 'Email is already associated with another account' });
+        }
+    } catch (error) {
+        console.error('Error checking email:', error);
+        return res.status(500).json({ message: 'Internal server error' });
+    }
+
     try {
         const userDetailsQuery = `
             SELECT up.first_name, up.last_name, u.email AS previous_email, up.phone 
@@ -147,6 +164,17 @@ router.put('/update-phone', authenticateToken, async (req, res) => {
     const phonePattern = /^\d{3}-\d{3}-\d{4}$/; // Expected format: 123-456-7890
     if (!phonePattern.test(phone)) {
         return res.status(400).json({ message: 'Invalid phone number format. Use XXX-XXX-XXXX' });
+    }
+
+    //Adding check for existing account with phone number
+    try {
+        const phoneExists = await pool.query('SELECT user_id FROM user_profiles WHERE phone = $1', [phone]);
+        if (phoneExists.rows.length > 0 && phoneExists.rows[0].user_id !== userId) {
+            return res.status(409).json({ message: 'Phone number is already associated with another account' });
+        }
+    } catch (error) {
+        console.error('Error checking phone number:', error);
+        return res.status(500).json({ message: 'Internal server error' });
     }
 
     try {


### PR DESCRIPTION
<img width="845" alt="settings1" src="https://github.com/user-attachments/assets/2a8bb223-a56b-433e-bd80-6788595e8319">
<img width="431" alt="settings2" src="https://github.com/user-attachments/assets/c51b6305-6243-4050-bf86-e4f9f499c55d">
<img width="450" alt="settings3" src="https://github.com/user-attachments/assets/a348e9b6-4a7a-4910-be85-ac33a5fd5aad">
<img width="482" alt="settings4" src="https://github.com/user-attachments/assets/75447c24-4bf5-41be-95d5-18084582999f">

**Issue / Feature:**
Update settings page with additional validation and UI improvements.

**Description:**
This PR enhances the settings page by adding a cancel button, email format validation, and uniqueness checks for email and phone number fields.

**What's in this change?:**
- Added a cancel button next to the save button in `EditableField` for better UX when editing.
- Backend validation to ensure email and phone number changes don’t conflict with existing accounts.
- Regex validation on the backend to check email format before saving. When registering my account, I noticed I could put "EbubeDivinee" as my email though that's clearly not a valid email. This also caused issues when email notifications were being sent out. 

**What's left to do?:**
All tasks for this feature are complete.

**Testing changes:**
- Confirmed that re-entering existing values (for the same account) works without errors.
- Tested backend responses to prevent duplicate email/phone usage.
- Verified that invalid email formats are correctly rejected.

**Supplemental material (optional, screenshots of frontend changes, api testing, notifications):**
See attached screenshot for updated settings page UI, including the new cancel button functionality.