### PR TITLE
Reverted page.js in account folder

### DIFF
--- a/client/app/account/page.js
+++ b/client/app/account/page.js
@@ -1,5 +1,5 @@
 'use client';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 
 import Navbar from "../components/navbar";
 import IngredientInput from './IngredientInput';
@@ -13,7 +13,6 @@ import styles from './account.module.css';
 
 const Pantry = () => {
   const router = useRouter();
-  const searchParams = useSearchParams();
   const [loading, setLoading] = useState(true);
   const [authenticated, setAuthenticated] = useState(false);
   const [activeSection, setActiveSection] = useState('Pantry');
@@ -24,11 +23,6 @@ const Pantry = () => {
   };
 
   useEffect(() => {
-    const section = searchParams.get('section');
-    if (section) {
-      setActiveSection(section.charAt(0).toUpperCase() + section.slice(1));
-    }
-
     const token = localStorage.getItem('token');
 
     const verifyToken = async () => {
@@ -62,7 +56,7 @@ const Pantry = () => {
     };
 
     verifyToken();
-  }, [router, searchParams]);
+  }, [router]);
 
   if (loading) {
     return <div>Loading...</div>;
@@ -109,7 +103,11 @@ const Pantry = () => {
           </div>
         </div>
         <div className={styles.pantrySection}>
-          {activeSection === 'Pantry' && <IngredientInput />}
+          {activeSection === 'Pantry' && (
+            <>
+              <IngredientInput />
+            </>
+          )}
           {activeSection === 'Allergens' && <AllergenInput />}
           {activeSection === 'Nutrition' && <NutritionInput />}
           {activeSection === 'History' && <RecipeHistory />}


### PR DESCRIPTION
**Issue / Feature:**
Fix deployment issue related to `useSearchParams` causing build failure on Render.

**Description:**
Reverted recent changes to the `account` page routing and removed `useSearchParams` to resolve deployment errors and ensure a stable build for the upcoming presentation. This rollback returns the page to its previous working state without section-specific routing via URL parameters.

**What's in this change?:**
- Removed `useSearchParams` in `page.js`.
- Reverted routing logic to default loading of the `Pantry` section without URL-based section targeting.

**What's left to do?:**
- Revisit section-specific routing with URL parameters once this is confirmed to deploy, potentially adding a `Suspense` fallback to manage component loading gracefully.

**Testing changes:**
- Verified that the page loads the `Pantry` section by default.
- Confirmed successful build and deployment on Render without `useSearchParams`.

**Supplemental material (optional, screenshots of frontend changes, api testing, notifications):**
N/A 
