### PR TITLE
Change ingredient add in recipe to a pop up

### DIFF
--- a/client/app/components/recipeDetail.module.css
+++ b/client/app/components/recipeDetail.module.css
@@ -181,6 +181,10 @@
     align-items: center;
 }
 
+.optionContainer{
+    position: fixed;
+}
+
 .optionButton {
     background-color: rgba(255, 207, 150, .8);
     color: #506264;
@@ -240,6 +244,8 @@
 }
 
 .customInputContainer {
+    background: white;
+    position: fixed;
     border-radius: 7px;
     padding: 0.5em;
     margin-top: 1em;


### PR DESCRIPTION
**Issue / Feature:**  
Change ingredient addition in a recipe to a pop-up modal.

**Description:**  
Replaced the inline add button functionality with a pop-up that allows users to input custom amounts and units for ingredients before adding them to their list.

**What's in this change?:**  
- Integrated a `ModalOverlay` component to display the pop-up for ingredient addition.  
- Users can select an ingredient, specify the amount and unit, and save it through the modal.  
- The modal overlays the page content for a cleaner and more intuitive UI.

**What's left to do?:**  
- Add error handling for invalid inputs in the modal (e.g., missing amount or unit).  
- Optimize styling for responsive layouts.  

**Testing changes:**  
- Ensure the modal opens when clicking the add button for a missed ingredient.  
- Verify that the ingredient moves from "missed" to "used" after saving through the modal.  
- Test cancel functionality to confirm the modal closes without changes.  

**Supplemental material (optional, screenshots of frontend changes, API testing, notifications):**  
_N/A_
