### PR TITLE
Add favor in favorite Button inside Recipe detail

### DIFF
--- a/client/app/components/FavoriteButton.js
+++ b/client/app/components/FavoriteButton.js
@@ -1,0 +1,73 @@
+import { useState, useEffect } from 'react';
+import axios from 'axios';
+import styles from './FavoriteButton.module.css'; // Create a CSS module for styles
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
+import FavoriteIcon from '@mui/icons-material/Favorite';
+
+const FavoriteButton = ({ recipeId }) => {
+    const [isFavorite, setIsFavorite] = useState(false);
+    const [loading, setLoading] = useState(false);
+
+    const checkFavoriteStatus = async () => {
+        const token = localStorage.getItem('token');
+        if (!token) return;
+
+        try {
+            const response = await axios.get(`${process.env.NEXT_PUBLIC_SERVER_URL}/api/favorites/check`, {
+                params: { recipeId },
+                headers: { Authorization: `Bearer ${token}` },
+            });
+            setIsFavorite(response.data.inFavorites);
+        } catch (error) {
+            console.error('Error checking favorite status:', error);
+        }
+    };
+
+    const toggleFavorite = async () => {
+        const token = localStorage.getItem('token');
+        if (!token) {
+            alert('Please log in to manage favorites.');
+            return;
+        }
+
+        setLoading(true);
+        try {
+            if (isFavorite) {
+                // Remove from favorites
+                await axios.delete(`${process.env.NEXT_PUBLIC_SERVER_URL}/api/favorites`, {
+                    data: { recipeId },
+                    headers: { Authorization: `Bearer ${token}` },
+                });
+                setIsFavorite(false);
+            } else {
+                // Add to favorites
+                await axios.post(`${process.env.NEXT_PUBLIC_SERVER_URL}/api/favorites`,
+                    { recipeId },
+                    { headers: { Authorization: `Bearer ${token}` } });
+                setIsFavorite(true);
+            }
+        } catch (error) {
+            console.error('Error toggling favorite status:', error);
+            alert('Failed to update favorite status. Please try again later.');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        checkFavoriteStatus();
+    }, [recipeId]);
+
+    return (
+        <button
+            className={`${styles.favoriteButton} ${isFavorite ? styles.active : ''}`}
+            onClick={toggleFavorite}
+            disabled={loading}
+            title={isFavorite ? 'Remove from Favorites' : 'Add to Favorites'}
+        >
+            {isFavorite ? <FavoriteIcon /> : <FavoriteBorderIcon />}
+        </button>
+    );
+};
+
+export default FavoriteButton;

--- a/client/app/components/FavoriteButton.module.css
+++ b/client/app/components/FavoriteButton.module.css
@@ -1,0 +1,20 @@
+.favoriteButton {
+    background: none;
+    border: none;
+    font-size: 2rem; /* Adjust icon size */
+    cursor: pointer;
+    transition: transform 0.2s;
+}
+
+.favoriteButton:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+}
+
+.favoriteButton:hover {
+    transform: scale(1.2);
+}
+
+.favoriteButton.active {
+    color: red;
+}

--- a/client/app/components/recipeDetail.js
+++ b/client/app/components/recipeDetail.js
@@ -17,6 +17,7 @@ import LoadingScreen from './loading';
 import { AddCircle, ConnectingAirportsOutlined } from '@mui/icons-material';
 import { useRouter } from 'next/navigation';
 import ErrorScreen from './error';
+import FavoriteButton from "@/app/components/FavoriteButton";
 
 // Recipe Image component
 const RecipeImage = ({ recipe }) => (
@@ -770,7 +771,10 @@ const RecipeDetails = ({ params }) => {
                 <div className={styles.errorWrapper}><ErrorScreen error={error}/></div>
             ) : recipe ? (
                 <div className={styles.recipeWrapper}>
-                    <div className={styles.recipeTitle}>{recipe.title}</div>
+                    <div className={styles.TitleWrapper}>
+                        <div className={styles.recipeTitle}>{recipe.title}</div>
+                        <FavoriteButton recipeId={recipe.id}/>
+                    </div>
                     <div className={styles.recipeContent}>
                         <div className={styles.recipeLeft}>
                             <RecipeImage recipe={recipe} />

--- a/client/app/components/recipeDetail.module.css
+++ b/client/app/components/recipeDetail.module.css
@@ -11,6 +11,12 @@
     align-items: center;
     width: 100%;
 }
+.TitleWrapper{
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 1rem;
+}
 
 .recipeContent {
     display: flex;

--- a/server/favoriteBackend/favorites.js
+++ b/server/favoriteBackend/favorites.js
@@ -138,4 +138,27 @@ router.get('/favorite-id', authenticateToken, async (req, res) => {
     }
 })
 
+// Check if a recipe is in favorites
+router.get('/check', authenticateToken, async (req, res) => {
+    const { recipeId } = req.query; // Expecting the recipe ID as a query parameter
+    const user_id = req.user.id;
+
+    try {
+        const favoriteQuery = await pool.query(
+            'SELECT * FROM user_favorites WHERE user_id = $1 AND recipe_id = $2',
+            [user_id, recipeId]
+        );
+
+        if (favoriteQuery.rows.length > 0) {
+            return res.status(200).json({ inFavorites: true, message: 'Recipe is in favorites.' });
+        }
+
+        res.status(200).json({ inFavorites: false, message: 'Recipe is not in favorites.' });
+    } catch (error) {
+        console.error('Error checking recipe in favorites:', error);
+        res.status(500).json({ message: 'Failed to check if recipe is in favorites.' });
+    }
+});
+
+
 module.exports = router;


### PR DESCRIPTION
# Issue / Feature: Add Favorite Button with Material UI Icons

**Description:**

This update adds a "Favorite" button that toggles between a filled and outlined heart using Material UI icons. It integrates with the backend to allow users to add or remove recipes from their favorites list.

**What's in this change?:**

- Replaced the heart emojis with Material UI's `FavoriteBorderIcon` and `FavoriteIcon` to visually represent the favorite state.
- Integrated an API call to check if a recipe is in the user's favorites.
- Updated the button logic to add or remove a recipe from the favorites list on click.

**What's left to do?:**

- Test the favorite button functionality with different user states (logged in, logged out).
- Verify API responses for success and error cases.
- Finalize frontend styling if needed (e.g., adjust button size, spacing).

**Testing changes:**

- Manually tested by clicking the button to add/remove recipes from favorites.
- Verified API requests and responses using Postman and browser network tools.
- Test cases to check:
  - Button shows the correct icon based on the favorite state.
  - Correct API requests are made for adding/removing favorites.
  - Disabled state for logged-out users with an alert.

**Supplemental material (optional, screenshots of frontend changes, API testing, notifications):**

- Screenshot showing the favorite button toggling between filled and outlined heart.
- 
<img width="1135" alt="image" src="https://github.com/user-attachments/assets/65c84732-2573-44c5-aaeb-ee647d2204dc">

- API response logs for successful and unsuccessful favorite operations.
